### PR TITLE
Tidy up README, relocate systemd unit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Get a recent version of [node.js and npm](https://github.com/nodesource/distribu
     cd /usr/local/var
     sudo git clone https://github.com/nwdigitalradio/draws-manager.git
     cd draws-manager
-    sudo cp draws-manager.service /lib/systemd/system
+    sudo cp draws-manager.service /etc/systemd/system
     sudo cp draws-manager /etc/default
+    sudo systemctl daemon-reload
 
 If you want to set the port, edit `/etc/default/draws-manager` and add a line with the port number, e.g. `PORT=80` (it defaults to 8080).
 
@@ -25,4 +26,3 @@ If you want to set the port, edit `/etc/default/draws-manager` and add a line wi
     sudo systemctl start draws-manager
 
 Open a browser and point it at the IP-address:port
-

--- a/README.md
+++ b/README.md
@@ -1,34 +1,28 @@
 # draws-manager
 Early development - NOT FOR DEPLOYMENT YET
 
-<b>THIS CODE RUNS UNDER ROOT, DO NOT EXPOSE TO THE OPEN INTERNET</b>
+**THIS CODE RUNS UNDER ROOT, DO NOT EXPOSE TO THE OPEN INTERNET**
 
-<h3>Alpha Code</h3>
-<h4>Prerequisites</h4>
-<b>sudo apt-get install nodejs npm git lm-sensors</b>
+## Alpha Code
 
-<b>sudo npm install -g npm</b>   #this updates npm, it will throw a couple of warnings, just ignore.
+## Prerequisites
 
-<b>Get a recent version of <a href="https://github.com/nodesource/distributions/blob/master/README.md#debinstall" target="new">node.js and npm</a> using the Debian instructions.<b>
+    sudo apt-get install nodejs npm git lm-sensors
+    sudo npm install -g npm  # this updates npm, it will throw a couple of warnings, just ignore.
 
-<b>cd /usr/local/var</b>
+Get a recent version of [node.js and npm](https://github.com/nodesource/distributions/blob/master/README.md#debinstall) using the Debian instructions.
 
-<b>sudo git clone https://github.com/nwdigitalradio/draws-manager.git</b>
+    cd /usr/local/var
+    sudo git clone https://github.com/nwdigitalradio/draws-manager.git
+    cd draws-manager
+    sudo cp draws-manager.service /lib/systemd/system
+    sudo cp draws-manager /etc/default
 
-<b>cd draws-manager</b>
+If you want to set the port, edit `/etc/default/draws-manager` and add a line with the port number, e.g. `PORT=80` (it defaults to 8080).
 
-<b>sudo cp draws-manager.service /lib/systemd/system</b>
-
-<b>sudo cp draws-manager /etc/default</b>
-
-<p># If you want to set the port, edit /etc/default/draws-manager and add a line with the port number, e.g. PORT=80 (it defaults to 8080)</p>
-
-<b>cd webapp</b>
-
-<b>sudo /usr/bin/npm install</b>  #this will take a while
-
-
-<b>sudo systemctl start draws-manager</b>
+    cd webapp
+    sudo /usr/bin/npm install  # this will take a while
+    sudo systemctl start draws-manager
 
 Open a browser and point it at the IP-address:port
 


### PR DESCRIPTION
Fixes up the README to be MarkDown content.

Also relocates the `draws-manager.service` file to the non-package install location in `/etc/systemd/system`.